### PR TITLE
Update SaveClientIdSubscriber.php

### DIFF
--- a/src/EventListener/SaveClientIdSubscriber.php
+++ b/src/EventListener/SaveClientIdSubscriber.php
@@ -31,7 +31,7 @@ final class SaveClientIdSubscriber implements EventSubscriberInterface
 
     public function save(ResponseEvent $event): void
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 


### PR DESCRIPTION
isMasterRequest() was deprecated since 5.3 and it was renamed in Symfony 6.0